### PR TITLE
Restore timezone after date calculations.

### DIFF
--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -44,10 +44,10 @@ final class Personnummer
      */
     private static function testDate($year, $month, $day)
 	{
-		$timezone = date_default_timezone_get();
-		$validDate = false;
+	    $timezone = date_default_timezone_get();
+	    $validDate = false;
 
-		try {
+	    try {
             date_default_timezone_set('Europe/Stockholm');
             $date = new DateTime($year . '-' . $month . '-' . $day);
 
@@ -66,9 +66,9 @@ final class Personnummer
             //pass
 		}
 
-		date_default_timezone_set($timezone);
+        date_default_timezone_set($timezone);
 
-		return $validDate;
+        return $validDate;
     }
 
     /**

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -45,7 +45,8 @@ final class Personnummer
     private static function testDate($year, $month, $day)
 	{
 		$timezone = date_default_timezone_get();
-	
+		$validDate = false;
+
 		try {
             date_default_timezone_set('Europe/Stockholm');
             $date = new DateTime($year . '-' . $month . '-' . $day);
@@ -62,7 +63,7 @@ final class Personnummer
                      $date->format('m') !== strval($month) ||
 					 $date->format('d') !== strval($day));
         } catch (Exception $e) {
-            $validDate = false;
+            //pass
 		}
 
 		date_default_timezone_set($timezone);

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -43,11 +43,11 @@ final class Personnummer
      * @return bool
      */
     private static function testDate($year, $month, $day)
-	{
-	    $timezone = date_default_timezone_get();
-	    $validDate = false;
+    {
+        $timezone = date_default_timezone_get();
+        $validDate = false;
 
-	    try {
+        try {
             date_default_timezone_set('Europe/Stockholm');
             $date = new DateTime($year . '-' . $month . '-' . $day);
 
@@ -60,11 +60,11 @@ final class Personnummer
             }
 
             $validDate = !(substr($date->format('Y'), 2) !== strval($year) ||
-                     $date->format('m') !== strval($month) ||
-					 $date->format('d') !== strval($day));
+                $date->format('m') !== strval($month) ||
+                $date->format('d') !== strval($day));
         } catch (Exception $e) {
             //pass
-		}
+        }
 
         date_default_timezone_set($timezone);
 

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -43,8 +43,10 @@ final class Personnummer
      * @return bool
      */
     private static function testDate($year, $month, $day)
-    {
-        try {
+	{
+		$timezone = date_default_timezone_get();
+	
+		try {
             date_default_timezone_set('Europe/Stockholm');
             $date = new DateTime($year . '-' . $month . '-' . $day);
 
@@ -56,12 +58,16 @@ final class Personnummer
                 $day = '0' . $day;
             }
 
-            return !(substr($date->format('Y'), 2) !== strval($year) ||
+            $validDate = !(substr($date->format('Y'), 2) !== strval($year) ||
                      $date->format('m') !== strval($month) ||
-                     $date->format('d') !== strval($day));
+					 $date->format('d') !== strval($day));
         } catch (Exception $e) {
-            return false;
-        }
+            $validDate = false;
+		}
+
+		date_default_timezone_set($timezone);
+
+		return $validDate;
     }
 
     /**

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -57,4 +57,25 @@ class PersonnummerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Personnummer::valid('900161-0017'));
         $this->assertFalse(Personnummer::valid('640893-3231'));
     }
+
+    public function testTimezone()
+    {
+        //Store the default timezone currently used.
+        $reset = date_default_timezone_get();
+
+        //Set a foreign timezone, in this case, New york.
+        date_default_timezone_set('America/New_York');
+
+        //This should pass, despite the foreign timezone.
+        $this->assertTrue(Personnummer::valid('701063-2391'));
+
+        //Get the timezone.
+        $timezone = date_default_timezone_get();
+
+        //We should still have the same timezone as the one we specified before.
+        $this->assertEquals('America/New_York', $timezone);
+
+        //Restore the original timezone so that we don't interfere with other tests.
+        date_default_timezone_set($reset);
+    }
 }


### PR DESCRIPTION
Restore timezone after date calculations in order to avoid side effects when a different timezone is used on the server.